### PR TITLE
Total weight for each serie

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Todo for MVP
 Tech todo
 - [] Test last performance
 - [] Test series (fixtures and system test)
+- [] Use form partial for series edit
 
 v1
 - [] "you should charge up" algorithm on last_performance: all reps > 10, and total superior from 2 last times

--- a/app/assets/stylesheets/form.css
+++ b/app/assets/stylesheets/form.css
@@ -103,8 +103,8 @@
 }
 
 .numeric {
-    width: 10ch;
-    max-width: 10ch;
+    width: 16ch;
+    max-width: 16ch;
 }
 
 

--- a/app/assets/stylesheets/form.css
+++ b/app/assets/stylesheets/form.css
@@ -103,16 +103,12 @@
 }
 
 .numeric {
-    width: 16ch;
+    min-width: 8ch;
     max-width: 16ch;
 }
-
 
 .weight_inputs {
     display: flex;
     flex-direction: row;
-    /* width: 100%;
-    max-width: 100%; */
-    justify-content: space-between;
-    text-align: center;
+    gap: var(--space-xs);
 }

--- a/app/assets/stylesheets/form.css
+++ b/app/assets/stylesheets/form.css
@@ -101,3 +101,18 @@
 .field_with_hint {
     margin-bottom: var(--space-xs);
 }
+
+.numeric {
+    width: 10ch;
+    max-width: 10ch;
+}
+
+
+.weight_inputs {
+    display: flex;
+    flex-direction: row;
+    /* width: 100%;
+    max-width: 100%; */
+    justify-content: space-between;
+    text-align: center;
+}

--- a/app/assets/stylesheets/list.css
+++ b/app/assets/stylesheets/list.css
@@ -47,6 +47,7 @@
     justify-content: space-between;
     border-bottom: var(--border);
     margin-bottom: var(--space-s);
+    padding-bottom: var(--space-s);
 }
 
 .list .list_inline {

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -63,6 +63,6 @@ class ExercisesController < ApplicationController
     end
 
     def exercise_params
-      params.require(:exercise).permit(:movement_id)
+      params.require(:exercise).permit(:movement_id, :movement_baseline_weight)
     end
 end

--- a/app/controllers/movements_controller.rb
+++ b/app/controllers/movements_controller.rb
@@ -53,7 +53,7 @@ class MovementsController < ApplicationController
 
   private
     def movement_params
-      params.require(:movement).permit(:name)
+      params.require(:movement).permit(:name, :equipment_type)
     end
 
     def set_movement

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -59,7 +59,7 @@ class SeriesController < ApplicationController
 
   private
     def serie_params
-      params.require(:serie).permit(:weight, :repetition, :is_total_weight)
+      params.require(:serie).permit(:weight, :repetition, :is_total_weight, :movement_baseline_weight)
     end
 
     def set_exercise

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -59,7 +59,7 @@ class SeriesController < ApplicationController
 
   private
     def serie_params
-      params.require(:serie).permit(:weight, :repetition, :is_total_weight, :movement_baseline_weight)
+      params.require(:serie).permit(:weight, :repetition, :is_total_weight)
     end
 
     def set_exercise

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -40,7 +40,7 @@ class SeriesController < ApplicationController
   def update
     if @serie.update(serie_params)
       respond_to do |format|
-        format.html {redirect_to workout_exercise_path(@workout,@exercise),notice: "Serie was successfully updated."}
+        format.html {redirect_to workout_exercise_path(@workout, @exercise),notice: "Serie was successfully updated."}
         format.turbo_stream { flash.now[:notice] = "Serie was successfully created." }
       end
     else
@@ -59,7 +59,7 @@ class SeriesController < ApplicationController
 
   private
     def serie_params
-      params.require(:serie).permit(:weight, :repetition)
+      params.require(:serie).permit(:weight, :repetition, :is_total_weight)
     end
 
     def set_exercise

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -4,6 +4,7 @@ class Exercise < ApplicationRecord
   has_many :series, class_name: 'Serie', dependent: :destroy
 
   validates_associated :series
+  validates :movement_baseline_weight, presence: true
 
   scope :ordered, -> { order(id: :asc) }
 

--- a/app/models/movement.rb
+++ b/app/models/movement.rb
@@ -1,6 +1,10 @@
 class Movement < ApplicationRecord
   belongs_to :user
+
+  enum equipment_type: [ :Barbell, :Dumbell, :Machine, :Cable ]
+
   validates :name, presence: true, uniqueness: { case_sensitive: false }
+
   scope :ordered, -> { order(name: :asc) }
   broadcasts_to ->(movement) { [movement.user, "movements"] }, inserts_by: :prepend
 end

--- a/app/models/movement.rb
+++ b/app/models/movement.rb
@@ -1,7 +1,7 @@
 class Movement < ApplicationRecord
   belongs_to :user
 
-  enum equipment_type: [ :Barbell, :Dumbell, :Machine, :Cable ]
+  enum equipment_type: [:barbell, :dumbell, :machine, :cable]
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
 

--- a/app/models/serie.rb
+++ b/app/models/serie.rb
@@ -4,4 +4,5 @@ class Serie < ApplicationRecord
   validates :weight, presence: true
   validates :repetition, presence: true
   validates :is_total_weight, inclusion: [true, false]
+  validates :movement_baseline_weight, presence: true
 end

--- a/app/models/serie.rb
+++ b/app/models/serie.rb
@@ -3,4 +3,5 @@ class Serie < ApplicationRecord
 
   validates :weight, presence: true
   validates :repetition, presence: true
+  validates :is_total_weight, presence: true
 end

--- a/app/models/serie.rb
+++ b/app/models/serie.rb
@@ -4,9 +4,8 @@ class Serie < ApplicationRecord
   validates :weight, presence: true
   validates :repetition, presence: true
   validates :is_total_weight, inclusion: [true, false]
-  validates :movement_baseline_weight, presence: true
 
   def total_weight
-    if is_total_weight then weight else weight*2+movement_baseline_weight end
+    if is_total_weight then weight else weight*2+exercise.movement_baseline_weight end
   end
 end

--- a/app/models/serie.rb
+++ b/app/models/serie.rb
@@ -3,5 +3,5 @@ class Serie < ApplicationRecord
 
   validates :weight, presence: true
   validates :repetition, presence: true
-  validates :is_total_weight, presence: true
+  validates :is_total_weight, inclusion: [true, false]
 end

--- a/app/models/serie.rb
+++ b/app/models/serie.rb
@@ -5,4 +5,8 @@ class Serie < ApplicationRecord
   validates :repetition, presence: true
   validates :is_total_weight, inclusion: [true, false]
   validates :movement_baseline_weight, presence: true
+
+  def total_weight
+    if is_total_weight then weight else weight*2+movement_baseline_weight end
+  end
 end

--- a/app/views/exercises/_exercise.html.erb
+++ b/app/views/exercises/_exercise.html.erb
@@ -2,8 +2,10 @@
     <% if exercise.movement_id %>
         <div class="list">
             <div class="list_header">
-                <h3><%= Movement.find(exercise.movement_id).name %></h3>
-
+                <div>
+                    <h3><%= exercise.movement.name %></h3>
+                    <p><%= exercise.movement.equipment_type.capitalize %> - Baseline weight: <%= exercise.movement_baseline_weight %> kg</p>
+                </div>
                 <%= turbo_frame_tag dom_id(exercise, :edit) do %>
                         <%= link_to "delete",
                             [workout, exercise],

--- a/app/views/exercises/_form.html.erb
+++ b/app/views/exercises/_form.html.erb
@@ -1,6 +1,7 @@
 <%= simple_form_for [ @workout, @workout.exercises.build ], html: { class: "form" } do |f| %>
   <%= form_error_notification(@exercise) %>
   <%= f.input :movement_id, collection: Movement.all.map { |m| [m.name, m.id] }%>
+  <%= f.input :movement_baseline_weight, placeholder: "Baseline weight" %>
   <div class="btn_group_inline">
     <%= link_to "Cancel", url_for(:back), class: "btn btn_light" %>
     <%= f.button :submit, class: "btn btn_secondary" %>

--- a/app/views/movements/_form.html.erb
+++ b/app/views/movements/_form.html.erb
@@ -1,6 +1,7 @@
 <%= simple_form_for @movement, html: { class: "form" } do |f| %>
     <%= form_error_notification(@movement) %>
     <%= f.input :name, placeholder: "Name your movement", hint: "Need to be unique" %>
+    <%= f.input :equipment_type, collection: Movement.equipment_types.map { |key, value| [key.humanize, key] }%>
     <div class="btn_group_inline">
         <%= link_to "Cancel", movements_path, class: "btn btn_light" %>
         <%= f.button :submit, class: "btn btn_secondary" %>

--- a/app/views/movements/_movement.html.erb
+++ b/app/views/movements/_movement.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag movement, class: "list_inline" do %>
-    <p><%= movement.name %></p>
+    <p><%= movement.name %> (<%= movement.equipment_type %>)</p>
     <div class="list_actions">
         <%= link_to "edit", edit_movement_path(movement), class: "material-symbols-outlined" %>
         <%= link_to "delete", movement_path(movement), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "material-symbols-outlined" %>

--- a/app/views/series/_form.html.erb
+++ b/app/views/series/_form.html.erb
@@ -3,6 +3,10 @@
   <div class="input_group">
     <%= f.input :weight, placeholder: "Weight in kilos" %>
     <%= f.input :is_total_weight, collection: [["in total", true], ["on each side", false]] %>
+    <%= f.input :weight,
+        placeholder: "Equipment weight",
+        input_html: { value: (@exercise.movement.barbell? ? "20" : "0") }
+        %>
     <%= f.input :repetition, placeholder: "Repetitions" %>
   </div>
   <div class="btn_group_inline">

--- a/app/views/series/_form.html.erb
+++ b/app/views/series/_form.html.erb
@@ -1,10 +1,12 @@
 <%= simple_form_for [@workout, @exercise, @exercise.series.build], url: workout_exercise_series_index_path(@workout, @exercise), html: { class: "form" } do |f| %>
   <%= form_error_notification(@serie) %>
-    <div class="weight_inputs">
-      <%= f.input :weight, placeholder: "Weight" %>
-      <%= f.input :is_total_weight, collection: [["in total", true], ["on each side", false]] %>
+    <div class="input_group">
+      <div class="weight_inputs">
+        <%= f.input :weight, placeholder: "Weight" %>
+        <%= f.input :is_total_weight, collection: [["in total", true], ["on each side", false]], include_blank: false, include_hidden: false %>
+      </div>
+      <%= f.input :repetition, placeholder: "Reps" %>
     </div>
-    <%= f.input :repetition, placeholder: "Reps" %>
   <div class="btn_group_inline">
     <%= link_to "Cancel", url_for(:back), class: "btn btn_light" %>
     <%= f.button :submit, class: "btn btn_secondary" %>

--- a/app/views/series/_form.html.erb
+++ b/app/views/series/_form.html.erb
@@ -3,7 +3,7 @@
   <div class="input_group">
     <%= f.input :weight, placeholder: "Weight in kilos" %>
     <%= f.input :is_total_weight, collection: [["in total", true], ["on each side", false]] %>
-    <%= f.input :weight,
+    <%= f.input :movement_baseline_weight,
         placeholder: "Equipment weight",
         input_html: { value: (@exercise.movement.barbell? ? "20" : "0") }
         %>

--- a/app/views/series/_form.html.erb
+++ b/app/views/series/_form.html.erb
@@ -1,14 +1,14 @@
 <%= simple_form_for [@workout, @exercise, @exercise.series.build], url: workout_exercise_series_index_path(@workout, @exercise), html: { class: "form" } do |f| %>
   <%= form_error_notification(@serie) %>
-  <div class="input_group">
-    <%= f.input :weight, placeholder: "Weight in kilos" %>
-    <%= f.input :is_total_weight, collection: [["in total", true], ["on each side", false]] %>
-    <%= f.input :movement_baseline_weight,
-        placeholder: "Equipment weight",
-        input_html: { value: (@exercise.movement.barbell? ? "20" : "0") }
-        %>
-    <%= f.input :repetition, placeholder: "Repetitions" %>
-  </div>
+    <div class="weight_inputs">
+      <%= f.input :weight, placeholder: "Weight" %>
+      <%= f.input :is_total_weight, collection: [["in total", true], ["on each side", false]] %>
+      <%= f.input :movement_baseline_weight,
+          placeholder: "Equipment weight",
+          input_html: { value: (@exercise.movement.barbell? ? "20" : "0") }
+          %>
+    </div>
+    <%= f.input :repetition, placeholder: "Reps" %>
   <div class="btn_group_inline">
     <%= link_to "Cancel", url_for(:back), class: "btn btn_light" %>
     <%= f.button :submit, class: "btn btn_secondary" %>

--- a/app/views/series/_form.html.erb
+++ b/app/views/series/_form.html.erb
@@ -1,7 +1,8 @@
 <%= simple_form_for [@workout, @exercise, @exercise.series.build], url: workout_exercise_series_index_path(@workout, @exercise), html: { class: "form" } do |f| %>
   <%= form_error_notification(@serie) %>
   <div class="input_group">
-    <%= f.input :weight, placeholder: "Weight in kilos"%>
+    <%= f.input :weight, placeholder: "Weight in kilos" %>
+    <%= f.input :is_total_weight, collection: [["in total", true], ["on each side", false]] %>
     <%= f.input :repetition, placeholder: "Repetitions" %>
   </div>
   <div class="btn_group_inline">

--- a/app/views/series/_form.html.erb
+++ b/app/views/series/_form.html.erb
@@ -3,10 +3,6 @@
     <div class="weight_inputs">
       <%= f.input :weight, placeholder: "Weight" %>
       <%= f.input :is_total_weight, collection: [["in total", true], ["on each side", false]] %>
-      <%= f.input :movement_baseline_weight,
-          placeholder: "Equipment weight",
-          input_html: { value: (@exercise.movement.barbell? ? "20" : "0") }
-          %>
     </div>
     <%= f.input :repetition, placeholder: "Reps" %>
   <div class="btn_group_inline">

--- a/app/views/series/_serie.html.erb
+++ b/app/views/series/_serie.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag serie do %>
     <%= turbo_frame_tag dom_id(serie, :edit) do %>
             <div class="list_inline">
-            <p><%= serie.weight %> kg - <%= pluralize(serie.repetition, 'reps') %></p>
+            <p><%= serie.weight %> kg (total: <%= serie.total_weight%> kg) - <%= pluralize(serie.repetition, 'reps') %> </p>
             <div class="list_actions">
             <%= link_to "edit",
                             [:edit, workout, exercise, serie],

--- a/app/views/series/edit.html.erb
+++ b/app/views/series/edit.html.erb
@@ -3,6 +3,11 @@
     <%= simple_form_for [@workout, @exercise, @serie], html: { class: "form" } do |f| %>
     <div class="input_group">
         <%= f.input :weight, placeholder: "Weight in kilos"%>
+        <%= f.input :is_total_weight, collection: [["in total", true], ["on each side", false]] %>
+        <%= f.input :movement_baseline_weight,
+            placeholder: "Equipment weight",
+            input_html: { value: (@exercise.movement.barbell? ? "20" : "0") }
+            %>
         <%= f.input :repetition, placeholder: "Repetitions" %>
     </div>
     <div class="btn_group_inline">

--- a/db/migrate/20230718142013_add_total_weight_boolean_to_series.rb
+++ b/db/migrate/20230718142013_add_total_weight_boolean_to_series.rb
@@ -1,0 +1,5 @@
+class AddTotalWeightBooleanToSeries < ActiveRecord::Migration[7.0]
+  def change
+    add_column :series, :is_total_weight, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20230718152412_add_type_to_movement.rb
+++ b/db/migrate/20230718152412_add_type_to_movement.rb
@@ -1,0 +1,5 @@
+class AddTypeToMovement < ActiveRecord::Migration[7.0]
+  def change
+    add_column :movements, :type, :integer
+  end
+end

--- a/db/migrate/20230718153552_change_type_to_equiment_type.rb
+++ b/db/migrate/20230718153552_change_type_to_equiment_type.rb
@@ -1,0 +1,5 @@
+class ChangeTypeToEquimentType < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :movements, :type, :equipment_type
+  end
+end

--- a/db/migrate/20230718162941_add_movement_baseline_weight_to_series.rb
+++ b/db/migrate/20230718162941_add_movement_baseline_weight_to_series.rb
@@ -1,0 +1,5 @@
+class AddMovementBaselineWeightToSeries < ActiveRecord::Migration[7.0]
+  def change
+    add_column :series, :movement_baseline_weight, :decimal, precision: 10, scale: 2, null: false, default: 0
+  end
+end

--- a/db/migrate/20230718182825_add_movement_baseline_weight_to_exercises.rb
+++ b/db/migrate/20230718182825_add_movement_baseline_weight_to_exercises.rb
@@ -1,0 +1,5 @@
+class AddMovementBaselineWeightToExercises < ActiveRecord::Migration[7.0]
+  def change
+    add_column :exercises, :movement_baseline_weight, :decimal, precision: 10, scale: 2, null: false, default: 0
+  end
+end

--- a/db/migrate/20230718183432_delete_default_in_movement_baseline_weight.rb
+++ b/db/migrate/20230718183432_delete_default_in_movement_baseline_weight.rb
@@ -1,0 +1,5 @@
+class DeleteDefaultInMovementBaselineWeight < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :exercises, :movement_baseline_weight, nil
+  end
+end

--- a/db/migrate/20230718184724_remove_movement_baseline_weight_from_series.rb
+++ b/db/migrate/20230718184724_remove_movement_baseline_weight_from_series.rb
@@ -1,0 +1,5 @@
+class RemoveMovementBaselineWeightFromSeries < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :series, :movement_baseline_weight
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_07_082440) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_18_142013) do
   create_table "exercises", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -35,6 +35,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_07_082440) do
     t.integer "exercise_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_total_weight", default: false, null: false
     t.index ["exercise_id"], name: "index_series_on_exercise_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_18_142013) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_18_153552) do
   create_table "exercises", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -25,6 +25,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_18_142013) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
+    t.integer "equipment_type"
     t.index ["name"], name: "index_movements_on_name", unique: true
     t.index ["user_id"], name: "index_movements_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_18_162941) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_18_184724) do
   create_table "exercises", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "workout_id", null: false
     t.integer "movement_id"
+    t.decimal "movement_baseline_weight", precision: 10, scale: 2, null: false
     t.index ["movement_id"], name: "index_exercises_on_movement_id"
     t.index ["workout_id"], name: "index_exercises_on_workout_id"
   end
@@ -37,7 +38,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_18_162941) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "is_total_weight", default: false, null: false
-    t.decimal "movement_baseline_weight", precision: 10, scale: 2, default: "0.0", null: false
     t.index ["exercise_id"], name: "index_series_on_exercise_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_18_153552) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_18_162941) do
   create_table "exercises", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -37,6 +37,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_18_153552) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "is_total_weight", default: false, null: false
+    t.decimal "movement_baseline_weight", precision: 10, scale: 2, default: "0.0", null: false
     t.index ["exercise_id"], name: "index_series_on_exercise_id"
   end
 


### PR DESCRIPTION
# Total weight for each serie

The overall goal of the app is to be able to give recommendation and statistics on the performances throughout the workouts. For now, the app isn't clear enough on what the weight means. For instance, my personal experience is that I like to log my workouts with the weight of each side, or on each hand... because it's a smaller number and you don't need calculation while loading the machine/bar or writing in your journal.

Though, especially with barbells, you have to take into account the "baseline" weight of the barbell, usually 20kgs, but sometimes 15kgs. For dumbbell, the baseline weight is 0kg. For machines, it's a bit more tricky: sometimes it's written on the machine, sometimes not. Anyways, sometimes you don't know or don't care.

Hence, this PR aims at making the upcoming performance stats easier and more precise once implemented.

## Pattern

- While selecting a weight, ask the user if this is the total weight or the weight on each side. Default is each side.
- Movements now have a `type` (: barbell, dumbell, cable, machine, other)
- On serie, ask the `movement_baseline_weight` of the barbell for the serie. Defaults: Barbell>20; Dunbell>0; Cable>0; Machine>0 and indicate the total.

## To-do

### Total weight boolean

- [x] Migration for is_total_weight:boolean in series schema, cannot be null, default to false.
- [x] Modify series model accordingly
- [x] Modify controller accordingly
- [x] Modify views, add boolean in form - user should understand that it's total or on each side

### Movement type 

- [x] Migration for type:int in movement schema, can be null, no default
- [x] Add in movement model the enum nature and validation: https://api.rubyonrails.org/v5.1/classes/ActiveRecord/Enum.html
- [x] Check if anything to change in controller
- [x] Modify views to have a select field for type at creation and update. Show the type on the show partial.

### Movement baseline weight for series

- [x] Add movement_baseline_weight field in series. Decimal, precision: 10, scale: 2, null false, default: 0
- [x] Model validation
- [x] Controller check
- [x] On serie form, show movement_baseline_weight with default 20 if the movement is of type barbell. Otherwise, default to 0. 

> EDIT: After thinking about it, I think it goes more naturally at the exercise level, since when one start an exercise, he doesn't change equipment.

- [x] Migration for `movement_baseline_weight` at the exercise level
- [x] Model validation 
- [x] Controller validation
- [x] Exercise create/update form > no default since we don't know the exercise yet
- [x] Show in the header of the exercise, with the exercise type.
- [x] Remove the above: schema, model, controller, views

### Total weight for serie
- [x] On serie model, add total_weight definition: if is_total_weight true then total_weight = weight, else, total-weight=weight*2+ movement_baseline_weight
- [x] On serie views show the total

### Make it shiny
- [x] Series form CSS: `total_weight` and `movement_baseline_weight` are more beautifully shown