### PR TITLE
Units of measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
     - [x] Devise views
 - [x] Form errors handling
 - [x] "On each side" vs "Total" weight indicator ~ https://github.com/MaximeRobion/workout_app/pull/2
-- [ ] Handle KG and LBS
+- [x] Handle KG and LBS
 - [ ] SuperSets (1 exercise with 2 movements)
 - [ ] Push to prod
 

--- a/app/assets/stylesheets/form.css
+++ b/app/assets/stylesheets/form.css
@@ -112,3 +112,13 @@
     flex-direction: row;
     gap: var(--space-xs);
 }
+
+form:invalid [type="submit"] {
+    pointer-events: none;
+    background-color: var(--color-background);
+    color: var(--color-text-muted);
+    background-image: none;
+    border: solid 2px transparent;
+    font-weight: bold;
+    transition: filter 400ms, color 200ms;
+  }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,11 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :exception
+  before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!, unless: :devise_controller?
+
+  protected
+    def configure_permitted_parameters
+        devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit(:preferred_unit, :email, :password)}
+        devise_parameter_sanitizer.permit(:account_update) { |u| u.permit(:preferred_unit, :email, :password, :current_password)}
+    end
 end

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -63,6 +63,6 @@ class ExercisesController < ApplicationController
     end
 
     def exercise_params
-      params.require(:exercise).permit(:movement_id, :movement_baseline_weight)
+      params.require(:exercise).permit(:movement_id, :movement_baseline_weight, :unit)
     end
 end

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -59,7 +59,7 @@ class SeriesController < ApplicationController
 
   private
     def serie_params
-      params.require(:serie).permit(:weight, :repetition, :is_total_weight, :units)
+      params.require(:serie).permit(:weight, :repetition, :is_total_weight, :unit)
     end
 
     def set_exercise

--- a/app/controllers/series_controller.rb
+++ b/app/controllers/series_controller.rb
@@ -59,7 +59,7 @@ class SeriesController < ApplicationController
 
   private
     def serie_params
-      params.require(:serie).permit(:weight, :repetition, :is_total_weight)
+      params.require(:serie).permit(:weight, :repetition, :is_total_weight, :units)
     end
 
     def set_exercise

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,7 @@ module ApplicationHelper
         object.errors.full_messages.to_sentence.capitalize
       end
     end
-end
+  end
 
   def nested_dom_id(*args)
     args.map { |arg| arg.respond_to?(:to_key) ? dom_id(arg) : arg }.join("_")

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -3,12 +3,19 @@ class Exercise < ApplicationRecord
   belongs_to :movement
   has_many :series, class_name: 'Serie', dependent: :destroy
 
+  enum unit: [:kg, :lbs]
+
   validates_associated :series
   validates :movement_baseline_weight, presence: true
+  validates :unit, presence: true
 
   scope :ordered, -> { order(id: :asc) }
 
   def previous_date
     workout.exercises.ordered.where("created_at < ?", created_at).last
+  end
+
+  def baseline_weight_and_unit
+    movement_baseline_weight.to_s + ' ' + unit
   end
 end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -15,7 +15,15 @@ class Exercise < ApplicationRecord
     workout.exercises.ordered.where("created_at < ?", created_at).last
   end
 
-  def baseline_weight_and_unit
-    movement_baseline_weight.to_s + ' ' + unit
+  def user_preferred_unit
+    workout.user.preferred_unit
+  end
+
+  def baseline_weight_in_preferred_unit
+    if user_preferred_unit == 'kg' && unit == 'kg' then movement_baseline_weight.to_s + ' kg'
+    elsif user_preferred_unit == 'kg' && unit == 'lbs' then movement_baseline_weight.to_kg.round(2).to_s + ' kg'
+    elsif user_preferred_unit == 'lbs' && unit == 'lbs' then movement_baseline_weight.to_s + ' lbs'
+    elsif user_preferred_unit == 'lbs' && unit == 'kg' then movement_baseline_weight.to_lbs.round(2).to_s + ' lbs'
+    end
   end
 end

--- a/app/models/serie.rb
+++ b/app/models/serie.rb
@@ -6,6 +6,7 @@ class Serie < ApplicationRecord
   validates :weight, presence: true
   validates :repetition, presence: true
   validates :is_total_weight, inclusion: [true, false]
+  validates :units, presence: true
 
   def total_weight
     if is_total_weight then weight else weight*2+exercise.movement_baseline_weight end

--- a/app/models/serie.rb
+++ b/app/models/serie.rb
@@ -1,6 +1,8 @@
 class Serie < ApplicationRecord
   belongs_to :exercise
 
+  enum units: [:kg, :lbs]
+
   validates :weight, presence: true
   validates :repetition, presence: true
   validates :is_total_weight, inclusion: [true, false]

--- a/app/models/serie.rb
+++ b/app/models/serie.rb
@@ -1,12 +1,12 @@
 class Serie < ApplicationRecord
   belongs_to :exercise
 
-  enum units: [:kg, :lbs]
+  enum unit: [:kg, :lbs]
 
   validates :weight, presence: true
   validates :repetition, presence: true
   validates :is_total_weight, inclusion: [true, false]
-  validates :units, presence: true
+  validates :unit, presence: true
 
   def total_weight
     if is_total_weight then weight else weight*2+exercise.movement_baseline_weight end

--- a/app/models/serie.rb
+++ b/app/models/serie.rb
@@ -11,4 +11,12 @@ class Serie < ApplicationRecord
   def total_weight
     if is_total_weight then weight else weight*2+exercise.movement_baseline_weight end
   end
+
+  def total_weight_and_unit
+    total_weight.to_s + ' ' + unit
+  end
+
+  def weight_and_unit
+    weight.to_s + ' ' + unit
+  end
 end

--- a/app/models/serie.rb
+++ b/app/models/serie.rb
@@ -8,15 +8,27 @@ class Serie < ApplicationRecord
   validates :is_total_weight, inclusion: [true, false]
   validates :unit, presence: true
 
-  def total_weight
-    if is_total_weight then weight else weight*2+exercise.movement_baseline_weight end
+  # Will need a fix if included again in the UI, since need to take into account everything
+  # in the right unit
+  # def total_weight
+  #   if is_total_weight then weight
+  #   else weight*2+exercise.movement_baseline_weight
+  #   end
+  # end
+
+  # def total_weight_and_unit
+  #   total_weight.to_s + ' ' + unit
+  # end
+
+  def user_preferred_unit
+    exercise.workout.user.preferred_unit
   end
 
-  def total_weight_and_unit
-    total_weight.to_s + ' ' + unit
-  end
-
-  def weight_and_unit
-    weight.to_s + ' ' + unit
+  def weight_in_preferred_unit
+    if user_preferred_unit == 'kg' && unit == 'kg' then weight.to_s + ' kg'
+    elsif user_preferred_unit == 'kg' && unit == 'lbs' then weight.to_kg.round(2).to_s + ' kg'
+    elsif user_preferred_unit == 'lbs' && unit == 'lbs' then weight.to_s + ' lbs'
+    elsif user_preferred_unit == 'lbs' && unit == 'kg' then weight.to_lbs.round(2).to_s + ' lbs'
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,10 @@ class User < ApplicationRecord
   has_many :workouts, dependent: :destroy
   has_many :movements, dependent: :destroy
 
+  enum preferred_unit: [:kg, :lbs]
+
+  validates :preferred_unit, presence: true
+
   def name
     email.split("@").first.capitalize
   end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,16 +1,16 @@
 <main class="container">
 <h2>Edit <%= resource_name.to_s.humanize %></h2>
 
-<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "form" }) do |f| %>
   <%= f.error_notification %>
 
-  <div class="form-inputs">
     <%= f.input :email, required: true, autofocus: true, placeholder: "Email" %>
 
     <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
       <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
     <% end %>
 
+    <div class="password_inputs">
     <%= f.input :password,
                 hint: "leave it blank if you don't want to change it",
                 required: false,
@@ -20,21 +20,27 @@
                 required: false,
                 input_html: { autocomplete: "new-password" },
                 placeholder: "New password confirmation" %>
+    </div>
+
+    <div>
+      <%= f.input :preferred_unit, collection: User.preferred_units.map { |key, value| [key.humanize, key] }, include_blank: false %>
+    </div>
+
     <%= f.input :current_password,
                 hint: "we need your current password to confirm your changes",
                 required: true,
                 input_html: { autocomplete: "current-password" },
                 placeholder: "Current password" %>
-  </div>
 
   <div class="form_actions_devise">
     <%= f.button :submit, "Update", class: "btn btn_primary" %>
   </div>
 <% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
 </main>
+<footer class="footer">
+  <%= button_to "Cancel my account",
+        registration_path(resource_name),
+        data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" },
+        method: :delete,
+        class: "btn btn_light" %>
+</footer>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -2,7 +2,7 @@
 <h2>Edit <%= resource_name.to_s.humanize %></h2>
 
 <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "form" }) do |f| %>
-  <%= f.error_notification %>
+    <%= form_error_notification(resource) %>
 
     <%= f.input :email, required: true, autofocus: true, placeholder: "Email" %>
 
@@ -23,7 +23,9 @@
     </div>
 
     <div>
-      <%= f.input :preferred_unit, collection: User.preferred_units.map { |key, value| [key.humanize, key] }, include_blank: false %>
+      <%= f.input :preferred_unit,
+                  collection: User.preferred_units.map { |key, value| [key.humanize, key] },
+                  include_blank: false %>
     </div>
 
     <%= f.input :current_password,

--- a/app/views/exercises/_exercise.html.erb
+++ b/app/views/exercises/_exercise.html.erb
@@ -6,7 +6,7 @@
                     <h3><%= exercise.movement.name %></h3>
                     <p><%= exercise.movement.equipment_type.capitalize %>
                         <% if exercise.movement_baseline_weight.positive? %>
-                            <%= "- #{exercise.movement_baseline_weight} kg" %>
+                            <%= "- #{exercise.baseline_weight_and_unit}" %>
                         <% end %>
                     </p>
                 </div>

--- a/app/views/exercises/_exercise.html.erb
+++ b/app/views/exercises/_exercise.html.erb
@@ -6,7 +6,7 @@
                     <h3><%= exercise.movement.name %></h3>
                     <p><%= exercise.movement.equipment_type.capitalize %>
                         <% if exercise.movement_baseline_weight.positive? %>
-                            <%= "- #{exercise.baseline_weight_and_unit}" %>
+                            <%= "- #{exercise.baseline_weight_in_preferred_unit}" %>
                         <% end %>
                     </p>
                 </div>

--- a/app/views/exercises/_form.html.erb
+++ b/app/views/exercises/_form.html.erb
@@ -1,7 +1,12 @@
 <%= simple_form_for [ @workout, @workout.exercises.build ], html: { class: "form" } do |f| %>
   <%= form_error_notification(@exercise) %>
-  <%= f.input :movement_id, collection: Movement.all.map { |m| [m.name, m.id] }%>
-  <%= f.input :movement_baseline_weight, placeholder: "Baseline weight" %>
+  <div class="input_group">
+    <%= f.input :movement_id, collection: Movement.all.map { |m| [m.name, m.id] }%>
+    <div class="weight_inputs">
+      <%= f.input :movement_baseline_weight, placeholder: "Baseline weight" %>
+      <%= f.input :unit, collection: Exercise.units.map { |key, value| [key.humanize, key] }, include_blank: false %>
+    </div>
+  </div>
   <div class="btn_group_inline">
     <%= link_to "Cancel", url_for(:back), class: "btn btn_light" %>
     <%= f.button :submit, class: "btn btn_secondary" %>

--- a/app/views/exercises/_last_performance.html.erb
+++ b/app/views/exercises/_last_performance.html.erb
@@ -3,7 +3,7 @@
         <p><%= local_time_ago(Exercise.where('created_at < ?', exercise.created_at).where(movement_id: exercise.movement_id).last.created_at) %></p>
         <ul>
             <% Serie.where(exercise_id: Exercise.where('created_at < ?', exercise.created_at).where(movement_id: exercise.movement_id).last.id).each do |last_serie| %>
-                <li class="small_text"><%= last_serie.weight %> kg x <%= last_serie.repetition %></li>
+                <li class="small_text"><%= last_serie.weight_and_unit %> x <%= last_serie.repetition %></li>
             <% end %>
         </ul>
     </div>

--- a/app/views/exercises/_last_performance.html.erb
+++ b/app/views/exercises/_last_performance.html.erb
@@ -3,7 +3,7 @@
         <p><%= local_time_ago(Exercise.where('created_at < ?', exercise.created_at).where(movement_id: exercise.movement_id).last.created_at) %></p>
         <ul>
             <% Serie.where(exercise_id: Exercise.where('created_at < ?', exercise.created_at).where(movement_id: exercise.movement_id).last.id).each do |last_serie| %>
-                <li class="small_text"><%= last_serie.weight_and_unit %> x <%= last_serie.repetition %></li>
+                <li class="small_text"><%= last_serie.weight_in_preferred_unit %> x <%= last_serie.repetition %></li>
             <% end %>
         </ul>
     </div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -7,6 +7,7 @@
     <div class="navbar_username">
       <%= current_user.name %>
     </div>
+    <%= link_to 'edit', edit_user_registration_path, class: "material-symbols-outlined" %>
     <%= button_to "logout",
                   destroy_user_session_path,
                   method: :delete,

--- a/app/views/series/_form.html.erb
+++ b/app/views/series/_form.html.erb
@@ -3,7 +3,8 @@
     <div class="input_group">
       <div class="weight_inputs">
         <%= f.input :weight, placeholder: "Weight" %>
-        <%= f.input :is_total_weight, collection: [["in total", true], ["on each side", false]], include_blank: false, include_hidden: false %>
+        <%= f.input :unit, collection: Serie.units.map { |key, value| [key.humanize, key] }, include_blank: false %>
+        <%= f.input :is_total_weight, collection: [["in total", true], ["on each side", false]], include_blank: false %>
       </div>
       <%= f.input :repetition, placeholder: "Reps" %>
     </div>

--- a/app/views/series/_serie.html.erb
+++ b/app/views/series/_serie.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag serie do %>
     <%= turbo_frame_tag dom_id(serie, :edit) do %>
             <div class="list_inline">
-            <p><%= serie.weight %> kg (total: <%= serie.total_weight%> kg) - <%= pluralize(serie.repetition, 'reps') %> </p>
+            <p><%= serie.weight_and_unit %> (total: <%= serie.total_weight_and_unit%>) - <%= pluralize(serie.repetition, 'reps') %> </p>
             <div class="list_actions">
             <%= link_to "edit",
                             [:edit, workout, exercise, serie],

--- a/app/views/series/_serie.html.erb
+++ b/app/views/series/_serie.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag serie do %>
     <%= turbo_frame_tag dom_id(serie, :edit) do %>
             <div class="list_inline">
-            <p><%= serie.weight_and_unit %> (total: <%= serie.total_weight_and_unit%>) - <%= pluralize(serie.repetition, 'reps') %> </p>
+            <p><%= serie.weight_in_preferred_unit %> - <%= pluralize(serie.repetition, 'reps') %> </p>
             <div class="list_actions">
             <%= link_to "edit",
                             [:edit, workout, exercise, serie],

--- a/app/views/series/edit.html.erb
+++ b/app/views/series/edit.html.erb
@@ -2,13 +2,12 @@
 <%= turbo_frame_tag dom_id(@serie, :edit) do %>
     <%= simple_form_for [@workout, @exercise, @serie], html: { class: "form" } do |f| %>
     <div class="input_group">
-        <%= f.input :weight, placeholder: "Weight in kilos"%>
-        <%= f.input :is_total_weight, collection: [["in total", true], ["on each side", false]] %>
-        <%= f.input :movement_baseline_weight,
-            placeholder: "Equipment weight",
-            input_html: { value: (@exercise.movement.barbell? ? "20" : "0") }
-            %>
-        <%= f.input :repetition, placeholder: "Repetitions" %>
+      <div class="weight_inputs">
+        <%= f.input :weight, placeholder: "Weight" %>
+        <%= f.input :unit, collection: Serie.units.map { |key, value| [key.humanize, key] }, include_blank: false %>
+        <%= f.input :is_total_weight, collection: [["in total", true], ["on each side", false]], include_blank: false %>
+      </div>
+      <%= f.input :repetition, placeholder: "Reps" %>
     </div>
     <div class="btn_group_inline">
         <%= link_to "Cancel", url_for(:back), class: "btn btn_light" %>

--- a/config/initializers/numeric_extensions.rb
+++ b/config/initializers/numeric_extensions.rb
@@ -1,0 +1,9 @@
+class Numeric
+  def to_lbs
+    self * 2.20462262185
+  end
+
+  def to_kg
+    self * 0.45359237
+  end
+end

--- a/db/migrate/20230719075845_add_unit_to_series.rb
+++ b/db/migrate/20230719075845_add_unit_to_series.rb
@@ -1,0 +1,5 @@
+class AddUnitToSeries < ActiveRecord::Migration[7.0]
+  def change
+    add_column :series, :unit, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20230719084431_add_unit_to_exercise.rb
+++ b/db/migrate/20230719084431_add_unit_to_exercise.rb
@@ -1,0 +1,5 @@
+class AddUnitToExercise < ActiveRecord::Migration[7.0]
+  def change
+    add_column :exercises, :unit, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20230719085049_add_preferred_unit_to_user.rb
+++ b/db/migrate/20230719085049_add_preferred_unit_to_user.rb
@@ -1,0 +1,5 @@
+class AddPreferredUnitToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :preferred_unit, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_19_075845) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_19_084431) do
   create_table "exercises", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "workout_id", null: false
     t.integer "movement_id"
     t.decimal "movement_baseline_weight", precision: 10, scale: 2, null: false
+    t.integer "unit", default: 0, null: false
     t.index ["movement_id"], name: "index_exercises_on_movement_id"
     t.index ["workout_id"], name: "index_exercises_on_workout_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_18_184724) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_19_075845) do
   create_table "exercises", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -38,6 +38,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_18_184724) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "is_total_weight", default: false, null: false
+    t.integer "unit", default: 0, null: false
     t.index ["exercise_id"], name: "index_series_on_exercise_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_19_084431) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_19_085049) do
   create_table "exercises", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -51,6 +51,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_19_084431) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "preferred_unit", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# Units of measurements

While kg are the baseline in Europe, it happens that one finds impossible to log the weight in kg, ie. the kg amount is unreadable. In that case, we want to give the ability to log the weight amount in lbs.

Also, it might be that people want to see all the weight amounts in kg or lbs to have homogeneity, so let's give the ability to have a preferred unit.

Hence:
- New `unit` field on the series, with enum, KG as default, select field, validation on model application to the views. 
- New `preferred_unit` field on users, with enum as well, default to KG a switch on the navbar to change it, an application helper to transfer everything to the preferred unit.

## Todo

### Units on serie
- [x] Migration: default kg, null: false
- [x] Define enum: kg, lbs
- [x] Model and controller validations
- [x] Views implementation: use unit everywhere in the app, maybe use helper function to have weight + unit.

### Units on movement baseline weight
- [x] Migration: default kg, null: false
- [x] Define enum: kg, lbs
- [x] Model and controller validations
- [x] Views implementation: use unit everywhere in the app, maybe use helper function to have weight + unit.

### Preferred unit for user
- [x] Migration: default kg, null: false
- [x] Define enum: kg, lbs
- [x] Model and controller validations
- [x] Views implementation:
 - [x] At the workout show level
 - [x] Use application helper to translate all in `weight_in_preferred_unit`